### PR TITLE
Add Ref Key Rooms

### DIFF
--- a/LotsofLoot/Config/config.jsonc
+++ b/LotsofLoot/Config/config.jsonc
@@ -109,6 +109,20 @@
       "5422acb9af1c889c16000029": 0.2
     }
   },
+  "RefRoomConfig": {
+    //Ref room loot multiplier, higher = more loot probability
+    "Multiplier": {
+        "woods": 1, //shatun
+        "interchange": 1, //grumpy
+        "shoreline": 1, //voron
+        "lighthouse": 1 //leon
+    },
+    //Multiplies the chance for a group of itemns to spawn in the room, higher number = more common
+    "ItemGroups": {
+      //Jewelry group
+      "57864a3d24597754843f8721": 0
+    }
+  },
   "LootinLooseContainer": {
     //Changes the max amount of items spawned in Loose Containers (things like item cases, docs cases and such.. Setting this to 0 will turn this behavior off.) | Value: 0 - 1
     "LootInContainerModifier": 1,
@@ -223,7 +237,7 @@
     //Graphics card
     "57347ca924597744596b4e71": 2
   },
-  //Multiplies the spawnchance of every pool with the specified item in it, Value: 0 - 1 
+  //Multiplies the spawnchance of every pool with the specified item in it, Value: 0 - 1
   "ChangeProbabilityOfPool": {
     //LEDX Skin Transilluminator
     "5c0530ee86f774697952d952": 1

--- a/LotsofLoot/ExtensionMethods.cs
+++ b/LotsofLoot/ExtensionMethods.cs
@@ -60,5 +60,50 @@ namespace LotsofLoot
 
             return false;
         }
+
+        public static bool IsRefKeySpawnpoint(this Spawnpoint spawnpoint, string locationId)
+        {
+            var pos = spawnpoint.Template?.Position;
+
+            if (pos is null)
+            {
+                return false;
+            }
+
+            if (locationId == "woods")
+            {
+                //shatun
+                if (pos.X > -514.5 && pos.X < -510.5 && pos.Z > -395.5 && pos.Z < -388 && pos.Y > 15.5 && pos.Y < 19)
+                {
+                    return true;
+                }
+            }
+            else if (locationId == "interchange")
+            {
+                //grumpy
+                if (pos.X > -200.5 && pos.X < -193 && pos.Z > -348 && pos.Z < -344 && pos.Y > 21 && pos.Y < 24)
+                {
+                    return true;
+                }
+            }
+            else if (locationId == "shoreline")
+            {
+                //voron
+                if (pos.X > -239.5 && pos.X < -235.5 && pos.Z > 191.5 && pos.Z < 199 && pos.Y > -41 && pos.Y < -37)
+                {
+                    return true;
+                }
+            }
+            else if (locationId == "lighthouse")
+            {
+                //leon
+                if (pos.X > -79.5 && pos.X < -75.5 && pos.Z > -297.5 && pos.Z < -288 && pos.Y > 9 && pos.Y < 12)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/LotsofLoot/LotsofLootModMetadata.cs
+++ b/LotsofLoot/LotsofLootModMetadata.cs
@@ -10,7 +10,7 @@ namespace LotsofLoot
         public override string Name { get; init; } = "Lots of Loot Redux";
         public override string Author { get; init; } = "ArchangelWTF";
         public override List<string>? Contributors { get; init; } = ["RainbowPC"];
-        public override Version Version { get; init; } = new("4.0.3");
+        public override Version Version { get; init; } = new("4.0.4");
         public override Range SptVersion { get; init; } = new("~4.0");
         public override List<string>? Incompatibilities { get; init; } = [];
         public override Dictionary<string, Range>? ModDependencies { get; init; } = [];

--- a/LotsofLoot/Models/Config/LotsofLootConfig.cs
+++ b/LotsofLoot/Models/Config/LotsofLootConfig.cs
@@ -72,6 +72,7 @@ namespace LotsofLoot.Models.Config
             };
 
         public MarkedRoomConfig MarkedRoomConfig { get; set; } = new();
+        public RefRoomConfig RefRoomConfig { get; set; } = new();
         public LootInLooseContainerConfig LootinLooseContainer { get; set; } = new();
 
         /// <summary>

--- a/LotsofLoot/Models/Config/RefRoomConfig.cs
+++ b/LotsofLoot/Models/Config/RefRoomConfig.cs
@@ -14,7 +14,7 @@ namespace LotsofLoot.Models.Config
                 { "woods", 1 },
                 // Grumpy
                 { "interchange", 1 },
-                // Shoreline
+                // Voron
                 { "shoreline", 1 },
                 // Leon
                 { "lighthouse", 1 },

--- a/LotsofLoot/Models/Config/RefRoomConfig.cs
+++ b/LotsofLoot/Models/Config/RefRoomConfig.cs
@@ -1,0 +1,33 @@
+using SPTarkov.Server.Core.Models.Common;
+
+namespace LotsofLoot.Models.Config
+{
+    public class RefRoomConfig
+    {
+        /// <summary>
+        /// Ref room loot multiplier, higher = more loot probability
+        /// </summary>
+        public Dictionary<string, double> Multiplier { get; set; } =
+            new Dictionary<string, double>()
+            {
+                // Shatun
+                { "woods", 1 },
+                // Grumpy
+                { "interchange", 1 },
+                // Shoreline
+                { "shoreline", 1 },
+                // Leon
+                { "lighthouse", 1 },
+            };
+
+        /// <summary>
+        /// Multiplies the chance for a group of items to spawn in the room, higher number = more common
+        /// </summary>
+        public Dictionary<MongoId, double> ItemGroups { get; set; } =
+            new Dictionary<MongoId, double>()
+            {
+                // Jewelery group
+                { "57864a3d24597754843f8721", 0d },
+            };
+    }
+}

--- a/LotsofLoot/Services/LazyLoadHandlerService.cs
+++ b/LotsofLoot/Services/LazyLoadHandlerService.cs
@@ -12,7 +12,7 @@ namespace LotsofLoot.Services
     public class LazyLoadHandlerService(
         DatabaseService databaseService,
         ConfigService configService,
-        MarkedRoomHelper markedRoomHelper,
+        LootRoomHelper markedRoomHelper,
         LotsOfLootLogger logger
     )
     {
@@ -98,7 +98,7 @@ namespace LotsofLoot.Services
                 ChangeRelativeProbabilityInPool(locationId, spawnpoint);
                 ChangeProbabilityOfPool(locationId, spawnpoint);
 
-                markedRoomHelper.AdjustMarkedRooms(locationId, spawnpoint);
+                markedRoomHelper.AdjustLootRooms(locationId, spawnpoint);
 
                 //Todo: This still needs AddToRustedKeyRoom for streets
             }


### PR DESCRIPTION
Adds the Ref key rooms support to the configs.
<img width="779" height="227" alt="image" src="https://github.com/user-attachments/assets/1f7b666e-751b-4acc-a8cd-377eddf34dd6" />

Its pretty much just an altered copy & paste job of the marked room config. I did not include adding new items as the ref keys don't seem to need it but it wouldn't take much to add if wanted.